### PR TITLE
Don't throw if missing messages file

### DIFF
--- a/ProductionModePlugin.js
+++ b/ProductionModePlugin.js
@@ -17,7 +17,7 @@ function ProductionModePlugin(attributes) {
   this.cldr = attributes.cldr || util.cldr;
   this.developmentLocale = attributes.developmentLocale;
   this.messages = attributes.messages && attributes.supportedLocales.reduce(function(sum, locale) {
-    sum[locale] = util.readMessages(attributes.messages, locale); 
+    sum[locale] = util.readMessages(attributes.messages, locale) || {};
     return sum;
   }, {});
   this.supportedLocales = attributes.supportedLocales;

--- a/util.js
+++ b/util.js
@@ -36,7 +36,8 @@ module.exports = {
   readMessages: function(messagesFilepath, locale) {
     messagesFilepath = messagesFilepath.replace("[locale]", locale);
     if (!fs.existsSync(messagesFilepath) || !fs.statSync(messagesFilepath).isFile()) {
-      throw new Error("Unable to find messages file: `" + messagesFilepath + "`");
+      console.warn("Unable to find messages file: `" + messagesFilepath + "`");
+      return null;
     }
     return JSON.parse(fs.readFileSync(messagesFilepath));
   },


### PR DESCRIPTION
Rationale: if in development mode for the plugin, the engineer might
have added strings in dev mode without having split them into a separate
messages file yet.

In production, we might be generating messages files for locales we
haven't written before - this step saves writing a new json file
manually each time.

Signed-off-by: Andrew Lunny <alunny@twitter.com>