### PR TITLE
production: remove all matching chunks correctly

### DIFF
--- a/ProductionModePlugin.js
+++ b/ProductionModePlugin.js
@@ -129,11 +129,16 @@ ProductionModePlugin.prototype.apply = function(compiler) {
         return /globalize-compiled-data/.test(chunk.name);
       });
       allModules.forEach(function(module) {
+        var chunkRemoved, chunk;
         if (globalizeCompilerHelper.isCompiledDataModule(module.request)) {
           hasAnyModuleBeenIncluded = true;
-          module.chunks.forEach(function(chunk) {
-            module.removeChunk(chunk);
-          });
+          while (module.chunks.length) {
+            chunk = module.chunks[0];
+            chunkRemoved = module.removeChunk(chunk);
+            if (!chunkRemoved) {
+              throw new Error("Failed to remove chunk " + chunk.id + " for module " + module.request);
+            }
+          }
           compiledDataChunks.forEach(function(compiledDataChunk) {
             compiledDataChunk.addModule(module);
             module.addChunk(compiledDataChunk);

--- a/util.js
+++ b/util.js
@@ -11,7 +11,7 @@ var isGlobalizeModule = function(filepath) {
   // 2: and it should appear either in the end (e.g., ../globalize) or right
   // before it (e.g., ../globalize/date).
   return i !== -1 /* 1 */ && filepath.length - i <= 2 /* 2 */;
-}
+};
 
 module.exports = {
   cldr: function(locale) {
@@ -44,7 +44,7 @@ module.exports = {
       } else {
         return !globalizeModule;
       }
-    }
+    };
   },
 
   readMessages: function(messagesFilepath, locale) {
@@ -71,6 +71,6 @@ module.exports = {
   },
 
   escapeRegex: function(string) {
-    return string.replace(/(?=[\/\\^$*+?.()|{}[\]])/g, "\\")
+    return string.replace(/(?=[\/\\^$*+?.()|{}[\]])/g, "\\");
   }
 };


### PR DESCRIPTION
Fixes #21 

Because `module.removeChunk` modifies the underlying array of
module.chunks, using `forEach` (or a for-loop over module.chunks.length)
is not guaranteed to cover all of the chunks in the original array.

This change guarantees that all chunks have the developmentLocale
modules removed, or throws an error.

(also includes some semicolons to please jshint)

Signed-off-by: Andrew Lunny <alunny@twitter.com>