### PR TITLE
Use hash for temporary files

### DIFF
--- a/GlobalizeCompilerHelper.js
+++ b/GlobalizeCompilerHelper.js
@@ -1,4 +1,4 @@
-var crypto = require('crypto');
+var crypto = require("crypto");
 var fs = require("fs");
 var globalizeCompiler = require("globalize-compiler");
 var path = require("path");
@@ -40,12 +40,29 @@ GlobalizeCompilerHelper.prototype.createCompiledDataModule = function(request) {
   return filepath;
 };
 
+var _tmpFilesMap = {};
+function assertUniqueTmpfile(filepath, tmpfile) {
+  if (_tmpFilesMap[tmpfile] != null) {
+    if (_tmpFilesMap[tmpfile] != filepath) {
+      throw new Error(
+        "Multiple files map to temporary file \"" + tmpfile + "\":\n" +
+        [_tmpFilesMap[tmpfile], filepath].join('\n')
+      );
+    }
+  } else {
+    _tmpFilesMap[tmpfile] = filepath;
+  }
+}
+
 GlobalizeCompilerHelper.prototype.getModuleFilepath = function(request) {
   var filepath = request.replace(/.*!/, "");
   var tmpfile = crypto
-    .createHash('sha1')
-    .update(filepath, 'utf8')
-    .digest('hex') + '.js';
+    .createHash("sha1")
+    .update(filepath, "utf8")
+    .digest("hex") + ".js";
+
+  assertUniqueTmpfile(filepath, tmpfile);
+
   return path.join(this.tmpdir, tmpfile);
 };
 

--- a/GlobalizeCompilerHelper.js
+++ b/GlobalizeCompilerHelper.js
@@ -1,3 +1,4 @@
+var crypto = require('crypto');
 var fs = require("fs");
 var globalizeCompiler = require("globalize-compiler");
 var path = require("path");
@@ -40,7 +41,12 @@ GlobalizeCompilerHelper.prototype.createCompiledDataModule = function(request) {
 };
 
 GlobalizeCompilerHelper.prototype.getModuleFilepath = function(request) {
-  return path.join(this.tmpdir, request.replace(/.*!/, "").replace(/[\/\\?" :]/g, "-"));
+  var filepath = request.replace(/.*!/, "");
+  var tmpfile = crypto
+    .createHash('sha1')
+    .update(filepath, 'utf8')
+    .digest('hex') + '.js';
+  return path.join(this.tmpdir, tmpfile);
 };
 
 GlobalizeCompilerHelper.prototype.compile = function(locale, request) {


### PR DESCRIPTION
Hash temporary file names.

Current encoding transforms the file path from where the Globalize calls
were extracted into a file name. In deeply nested projects, this can
double the length of the path, causing E_NAMETOOLONG issues.

Before this:
/long/path/to/project/.tmp-globalize-webpack/-long-path-to-project-src-component-foo-index.js
After this:
/long/path/to/project/.tmp-globalize-webpack/5b4c40dd44a2cfde54a3e04cd183aa70edd64c1a.js

This has the downside that it makes the content of the files more opaque, being
harder to debug which content maps to which file. One would have to
```
echo -n `readlink -f src/component/foo/index.js` | shasum
```

Fixes #42 and #16.