### PR TITLE
add support for string module ids

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 node_modules/
-test/output
+_test-output
 .tmp-globalize-webpack/

--- a/ProductionModePlugin.js
+++ b/ProductionModePlugin.js
@@ -214,8 +214,16 @@ ProductionModePlugin.prototype.apply = function(compiler) {
             // While request has the full pathname, aux has something like "globalize/dist/globalize-runtime/date".
             aux = request.split(/[\/\\]/);
             aux = aux.slice(aux.lastIndexOf("globalize")).join("/").replace(/\.js$/, "");
-            globalizeModuleIds.push(module.id);
-            globalizeModuleIdsMap[aux] = module.id;
+
+            // some plugins, like HashedModuleIdsPlugin, may change module ids
+            // into strings.
+            var moduleId = module.id;
+            if (typeof moduleId === "string") {
+              moduleId = JSON.stringify(moduleId);
+            }
+
+            globalizeModuleIds.push(moduleId);
+            globalizeModuleIdsMap[aux] = moduleId;
           }
         });
       });

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Globalize.js webpack plugin",
   "main": "index.js",
   "scripts": {
-    "test": "eslint *js && mocha test"
+    "test": "eslint *js test && mocha test"
   },
   "repository": {
     "type": "git",
@@ -38,10 +38,11 @@
     "eslint": "^3.19.0",
     "eslint-config-defaults": "^9.0.0",
     "globalize": "^1.2.3",
+    "mkdirp": "^0.5.1",
     "mocha": "^3.3.0",
     "path-chunk-webpack-plugin": "^1.2.0",
     "rimraf": "^2.6.1",
-    "webpack": "^1.15.0"
+    "webpack": "^2.5.1"
   },
   "cldr-data-urls-filter": "(core|dates|numbers|units)"
 }

--- a/test/ProductionModePlugin.js
+++ b/test/ProductionModePlugin.js
@@ -1,36 +1,55 @@
-var expect = require("chai").expect;
 var GlobalizePlugin = require("../index");
-var PathChunkPlugin = require("path-chunk-webpack-plugin");
-var path = require("path");
-var webpack = require("webpack");
-var rimraf = require("rimraf");
+var expect = require("chai").expect;
 var fs = require("fs");
+var mkdirp = require("mkdirp");
+var path = require("path");
+var rimraf = require("rimraf");
+var webpack = require("webpack");
 
-var OUTPUT_PATH = path.join(__dirname, "output");
-
-var webpackConfig = {
-  entry: {
-    app: path.join(__dirname, "fixtures/app")
-  },
-  output: {
-    path: OUTPUT_PATH,
-    filename: "app.js"
-  },
-  plugins: [
-    new GlobalizePlugin({
-      production: true,
-      developmentLocale: "en",
-      supportedLocales: ["en"],
-      messages: path.join(__dirname, "fixtures/translations/[locale].json"),
-      output: "[locale].js"
-    }),
-    // new webpack.optimize.DedupePlugin(),
-    new PathChunkPlugin({
-      name: "vendor",
-      test: "node_modules/"
-    })
-  ]
+var TEST_CASES = {
+  default: [],
+  named: [ new webpack.NamedModulesPlugin() ],
+  hashed: [ new webpack.HashedModuleIdsPlugin() ]
 };
+
+function outputPath(key, file) {
+  return path.join(__dirname, "../_test-output", key, file || "");
+}
+
+function mkWebpackConfig(key) {
+  return {
+    entry: {
+      app: path.join(__dirname, "fixtures/app")
+    },
+    output: {
+      path: outputPath(key),
+      filename: "app.js"
+    },
+    plugins: TEST_CASES[key].concat([
+      new GlobalizePlugin({
+        production: true,
+        developmentLocale: "en",
+        supportedLocales: ["en"],
+        messages: path.join(__dirname, "fixtures/translations/[locale].json"),
+        output: "[locale].js"
+      }),
+      // new webpack.NamedModulesPlugin(),
+      new webpack.optimize.CommonsChunkPlugin({
+        name: "vendor",
+        filename: "vendor.js",
+        minChunks: function(module) {
+          const nodeModules = path.resolve(__dirname, "../node_modules");
+          return module.request && module.request.startsWith(nodeModules);
+        }
+      }),
+      new webpack.optimize.CommonsChunkPlugin({
+        name: "runtime",
+        filename: "runtime.js",
+        minChunks: Infinity
+      })
+    ])
+  };
+}
 
 function promisefiedWebpack(config) {
   return new Promise(function(resolve, reject) {
@@ -45,89 +64,103 @@ function promisefiedWebpack(config) {
 
 describe("Globalize Webpack Plugin", function() {
   describe("Production Mode", function() {
-    describe("Basic app", function() {
-      before(function(done) {
-        rimraf(OUTPUT_PATH, function() {
-          fs.mkdirSync(OUTPUT_PATH);
-          done();
-        });
-      });
+    Object.keys(TEST_CASES).forEach(function(key) {
+      describe(`when using ${key} module ids`, function() {
+        var webpackConfig = mkWebpackConfig(key);
+        var myOutputPath = outputPath(key);
+        var compileStats;
 
-      it("should extract formatters and parsers from basic code", function() {
-        return expect(promisefiedWebpack(webpackConfig)).to.eventually.be.fulfilled.then(function(stats) {
-          var outputFilepath = path.join(OUTPUT_PATH, "en.js");
+        before(function(done) {
+          rimraf(myOutputPath, function() {
+            mkdirp.sync(myOutputPath);
+            promisefiedWebpack(webpackConfig)
+              .catch(done)
+              .then(function (stats) {
+                compileStats = stats;
+                done();
+              });
+          });
+        });
+
+        it("should extract formatters and parsers from basic code", function() {
+          var outputFilepath = path.join(myOutputPath, "en.js");
           var outputFileExists = fs.existsSync(outputFilepath);
           expect(outputFileExists).to.be.true;
           var content = fs.readFileSync(outputFilepath).toString();
           expect(content).to.be.a("string");
         });
-      });
 
-      describe("The compiled bundle", function() {
-        var Globalize;
+        describe("The compiled bundle", function() {
+          var Globalize;
 
-        before(function() {
-          global.window = global;
-          // Hack: Expose __webpack_require__.
-          var appFilepath = path.join(__dirname, "./output/app.js");
-          var appContent = fs.readFileSync(appFilepath).toString();
-          fs.writeFileSync(appFilepath, appContent.replace(/(function __webpack_require__\(moduleId\) {)/, "window.__webpack_require__ = $1"));
+          before(function() {
+            global.window = global;
+            // Hack: Expose __webpack_require__.
+            var runtimeFilePath = outputPath(key, "runtime.js");
+            var runtimeContent = fs.readFileSync(runtimeFilePath).toString();
+            fs.writeFileSync(runtimeFilePath, runtimeContent.replace(/(function __webpack_require__\(moduleId\) {)/, "window.__webpack_require__ = $1"));
 
-          // Hack2: Load compiled Globalize
-          require("./output/app");
-          require("./output/en");
-          Globalize = global.__webpack_require__(1);
+            // Hack2: Load compiled Globalize
+            require(outputPath(key, "runtime"));
+            require(outputPath(key, "vendor"));
+            require(outputPath(key, "en"));
+            require(outputPath(key, "app"));
 
-          Globalize.locale("en");
-        });
+            const globalizeModuleStats = compileStats.toJson().modules.find(function (module) {
+              return module.name === "./~/globalize/dist/globalize-runtime.js";
+            });
 
-        after(function() {
-          delete global.window;
-          delete global.webpackJsonp;
-        });
+            Globalize = global.__webpack_require__(globalizeModuleStats.id);
+          });
 
-        it("should include formatDate", function() {
-          var result = Globalize.formatDate(new Date(2017, 3, 15), {datetime: "medium"});
-          // Note, the reason for the loose match below is due to ignore the local time zone differences.
-          expect(result).to.have.string("Apr");
-          expect(result).to.have.string("2017");
-        });
+          after(function() {
+            delete global.window;
+            delete global.webpackJsonp;
+          });
 
-        it("should include formatNumber", function() {
-          var result = Globalize.formatNumber(Math.PI);
-          expect(result).to.equal("3.142");
-        });
+          it("should include formatDate", function() {
+            var result = Globalize.formatDate(new Date(2017, 3, 15), {datetime: "medium"});
+            // Note, the reason for the loose match below is due to ignore the local time zone differences.
+            expect(result).to.have.string("Apr");
+            expect(result).to.have.string("2017");
+          });
 
-        it("should include formatCurrency", function() {
-          var result = Globalize.formatCurrency(69900, "USD");
-          expect(result).to.equal("$69,900.00");
-        });
+          it("should include formatNumber", function() {
+            var result = Globalize.formatNumber(Math.PI);
+            expect(result).to.equal("3.142");
+          });
 
-        it("should include formatMessage", function() {
-          var result = Globalize.formatMessage("like", 0);
-          expect(result).to.equal("Be the first to like this");
-        });
+          it("should include formatCurrency", function() {
+            var result = Globalize.formatCurrency(69900, "USD");
+            expect(result).to.equal("$69,900.00");
+          });
 
-        it("should include formatRelativeTime", function() {
-          var result = Globalize.formatRelativeTime(1, "second");
-          expect(result).to.equal("in 1 second");
-        });
+          it("should include formatMessage", function() {
+            var result = Globalize.formatMessage("like", 0);
+            expect(result).to.equal("Be the first to like this");
+          });
 
-        it("should include formatUnit", function() {
-          var result = Globalize.formatUnit(60, "mile/hour", {form: "short"});
-          expect(result).to.equal("60 mph");
-        });
+          it("should include formatRelativeTime", function() {
+            var result = Globalize.formatRelativeTime(1, "second");
+            expect(result).to.equal("in 1 second");
+          });
 
-        it("should include parseNumber", function() {
-          var result = Globalize.parseNumber("1,234.56");
-          expect(result).to.equal(1234.56);
-        });
+          it("should include formatUnit", function() {
+            var result = Globalize.formatUnit(60, "mile/hour", {form: "short"});
+            expect(result).to.equal("60 mph");
+          });
 
-        it("should include parseDate", function() {
-          var result = Globalize.parseDate("1/2/1982");
-          expect(result.getFullYear()).to.equal(1982);
-          expect(result.getMonth()).to.equal(0);
-          expect(result.getDate()).to.equal(2);
+          it("should include parseNumber", function() {
+            var result = Globalize.parseNumber("1,234.56");
+            expect(result).to.equal(1234.56);
+          });
+
+          it("should include parseDate", function() {
+            var result = Globalize.parseDate("1/2/1982");
+            expect(result.getFullYear()).to.equal(1982);
+            expect(result.getMonth()).to.equal(0);
+            expect(result.getDate()).to.equal(2);
+          });
         });
       });
     });

--- a/test/fixtures/app.js
+++ b/test/fixtures/app.js
@@ -2,32 +2,32 @@ var like;
 var Globalize = require( "globalize" );
 
 // Use Globalize to format dates.
-console.log( Globalize.formatDate( new Date(), { datetime: "medium" } ) );
+Globalize.formatDate( new Date(), { datetime: "medium" } );
 
 // Use Globalize to format numbers.
-console.log( Globalize.formatNumber( 12345.6789 ) );
+Globalize.formatNumber( 12345.6789 );
 
 // Use Globalize to format currencies.
-console.log( Globalize.formatCurrency( 69900, "USD" ) );
+Globalize.formatCurrency( 69900, "USD" );
 
 // Use Globalize to get the plural form of a numeric value.
-console.log( Globalize.plural( 12345.6789 ) );
+Globalize.plural( 12345.6789 );
 
 // Use Globalize to format a message with plural inflection.
 like = Globalize.messageFormatter( "like" );
-console.log( like( 0 ) );
-console.log( like( 1 ) );
-console.log( like( 2 ) );
-console.log( like( 3 ) );
+like( 0 );
+like( 1 );
+like( 2 );
+like( 3 );
 
 // Use Globalize to format relative time.
-console.log( Globalize.formatRelativeTime( -35, "second" ) );
+Globalize.formatRelativeTime( -35, "second" );
 
 // Use Globalize to format unit.
-console.log( Globalize.formatUnit( 60, "mile/hour", { form: "short" } ) );
+Globalize.formatUnit( 60, "mile/hour", { form: "short" } );
 
 // Use Globalize to parse a number.
-console.log( Globalize.parseNumber( "12345.6789" ) );
+Globalize.parseNumber( "12345.6789" );
 
 // Use Globalize to parse a date.
-console.log( Globalize.parseDate( "1/2/1982" ) );
+Globalize.parseDate( "1/2/1982" );


### PR DESCRIPTION
ProductionModePlugin writes module ids as unescaped values. This works for the most common case of integer module ids, but not for strings. Trying to use ProductionModePlugin with something like [NamedModulesPlugin](https://github.com/webpack/webpack/blob/master/lib/NamedModulesPlugin.js), renders the snippet below which throws a syntax error at runtime:

```javascript
module.exports = factory( __webpack_require__(./node_modules/globalize/dist/globalize-runtime/number.js), __webpack_require__(./node_modules/globalize/dist/globalize-runtime/plural.js), __webpack_require__(./node_modules/globalize/dist/globalize-runtime/message.js), __webpack_require__(./node_modules/globalize/dist/globalize-runtime/currency.js), __webpack_require__(./node_modules/globalize/dist/globalize-runtime/date.js), __webpack_require__(./node_modules/globalize/dist/globalize-runtime/relative-time.js), __webpack_require__(./node_modules/globalize/dist/globalize-runtime/unit.js) );
```

This PR adds support for quoting module ids that look like strings.