### PR TITLE
Tests (finally)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 node_modules/
+test/output
+.tmp-globalize-webpack/

--- a/ProductionModePlugin.js
+++ b/ProductionModePlugin.js
@@ -227,7 +227,7 @@ ProductionModePlugin.prototype.apply = function(compiler) {
         chunk.files.filter(ModuleFilenameHelpers.matchObject).forEach(function(file) {
           var isFirst = true;
           // Match either webpack 1.x or webpack 2.x
-          var source = compilation.assets[file].source().replace(/\n\/\*\*\*\/ \(?function\(module, exports(, __webpack_require__)?\) {[\s\S]*?(\n\/\*\*\*\/ })/g, function(garbage1, garbage2, fnTail) {
+          var source = compilation.assets[file].source().replace(/\n\/\*\*\*\/ (\(?function)\(module, exports(, __webpack_require__)?\) {[\s\S]*?(\n\/\*\*\*\/ })/g, function(garbage1, fnHead, garbage2, fnTail) {
             var fnContent;
 
             // Define the initial module 0 as the whole formatters and parsers.
@@ -244,15 +244,7 @@ ProductionModePlugin.prototype.apply = function(compiler) {
               fnContent = "module.exports = __webpack_require__(" + globalizeModuleIds[0] + ");";
             }
 
-            // Hack to support webpack 1.x and 2.x.
-            // webpack 2.x
-            if (NormalModuleFactory.prototype.createParser) {
-              return "\n/***/ (function(module, exports, __webpack_require__) {\n" + fnContent + fnTail;
-
-            // webpack 1.x
-            } else {
-              return "\n/***/ function(module, exports, __webpack_require__) {\n" + fnContent + fnTail;
-            }
+            return "\n/***/ " + fnHead + "(module, exports, __webpack_require__) {\n" + fnContent + fnTail;
           });
           compilation.assets[file] = new ConcatSource(source);
         });

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Globalize.js webpack plugin",
   "main": "index.js",
   "scripts": {
-    "test": "eslint *js"
+    "test": "eslint *js && mocha test"
   },
   "repository": {
     "type": "git",
@@ -32,7 +32,16 @@
     "webpack": "^1.9.0 || ^2.2.0-rc"
   },
   "devDependencies": {
+    "chai": "^3.5.0",
+    "chai-as-promised": "^6.0.0",
+    "cldr-data": "^31.0.2",
     "eslint": "^3.19.0",
-    "eslint-config-defaults": "^9.0.0"
-  }
+    "eslint-config-defaults": "^9.0.0",
+    "globalize": "^1.2.3",
+    "mocha": "^3.3.0",
+    "path-chunk-webpack-plugin": "^1.2.0",
+    "rimraf": "^2.6.1",
+    "webpack": "^1.15.0"
+  },
+  "cldr-data-urls-filter": "(core|dates|numbers|units)"
 }

--- a/test/ProductionModePlugin.js
+++ b/test/ProductionModePlugin.js
@@ -1,0 +1,135 @@
+var expect = require("chai").expect;
+var GlobalizePlugin = require("../index");
+var PathChunkPlugin = require("path-chunk-webpack-plugin");
+var path = require("path");
+var webpack = require("webpack");
+var rimraf = require("rimraf");
+var fs = require("fs");
+
+var OUTPUT_PATH = path.join(__dirname, "output");
+
+var webpackConfig = {
+  entry: {
+    app: path.join(__dirname, "fixtures/app")
+  },
+  output: {
+    path: OUTPUT_PATH,
+    filename: "app.js"
+  },
+  plugins: [
+    new GlobalizePlugin({
+      production: true,
+      developmentLocale: "en",
+      supportedLocales: ["en"],
+      messages: path.join(__dirname, "fixtures/translations/[locale].json"),
+      output: "[locale].js"
+    }),
+    // new webpack.optimize.DedupePlugin(),
+    new PathChunkPlugin({
+      name: "vendor",
+      test: "node_modules/"
+    })
+  ]
+};
+
+function promisefiedWebpack(config) {
+  return new Promise(function(resolve, reject) {
+    webpack(config, function(error, stats) {
+      if (error) {
+        return reject(error);
+      }
+      return resolve(stats);
+    });
+  });
+}
+
+describe("Globalize Webpack Plugin", function() {
+  describe("Production Mode", function() {
+    describe("Basic app", function() {
+      before(function(done) {
+        rimraf(OUTPUT_PATH, function() {
+          fs.mkdirSync(OUTPUT_PATH);
+          done();
+        });
+      });
+
+      it("should extract formatters and parsers from basic code", function() {
+        return expect(promisefiedWebpack(webpackConfig)).to.eventually.be.fulfilled.then(function(stats) {
+          var outputFilepath = path.join(OUTPUT_PATH, "en.js");
+          var outputFileExists = fs.existsSync(outputFilepath);
+          expect(outputFileExists).to.be.true;
+          var content = fs.readFileSync(outputFilepath).toString();
+          expect(content).to.be.a("string");
+        });
+      });
+
+      describe("The compiled bundle", function() {
+        var Globalize;
+
+        before(function() {
+          global.window = global;
+          // Hack: Expose __webpack_require__.
+          var appFilepath = path.join(__dirname, "./output/app.js");
+          var appContent = fs.readFileSync(appFilepath).toString();
+          fs.writeFileSync(appFilepath, appContent.replace(/(function __webpack_require__\(moduleId\) {)/, "window.__webpack_require__ = $1"));
+
+          // Hack2: Load compiled Globalize
+          require("./output/app");
+          require("./output/en");
+          Globalize = global.__webpack_require__(1);
+
+          Globalize.locale("en");
+        });
+
+        after(function() {
+          delete global.window;
+          delete global.webpackJsonp;
+        });
+
+        it("should include formatDate", function() {
+          var result = Globalize.formatDate(new Date(2017, 3, 15), {datetime: "medium"});
+          // Note, the reason for the loose match below is due to ignore the local time zone differences.
+          expect(result).to.have.string("Apr");
+          expect(result).to.have.string("2017");
+        });
+
+        it("should include formatNumber", function() {
+          var result = Globalize.formatNumber(Math.PI);
+          expect(result).to.equal("3.142");
+        });
+
+        it("should include formatCurrency", function() {
+          var result = Globalize.formatCurrency(69900, "USD");
+          expect(result).to.equal("$69,900.00");
+        });
+
+        it("should include formatMessage", function() {
+          var result = Globalize.formatMessage("like", 0);
+          expect(result).to.equal("Be the first to like this");
+        });
+
+        it("should include formatRelativeTime", function() {
+          var result = Globalize.formatRelativeTime(1, "second");
+          expect(result).to.equal("in 1 second");
+        });
+
+        it("should include formatUnit", function() {
+          var result = Globalize.formatUnit(60, "mile/hour", {form: "short"});
+          expect(result).to.equal("60 mph");
+        });
+
+        it("should include parseNumber", function() {
+          var result = Globalize.parseNumber("1,234.56");
+          expect(result).to.equal(1234.56);
+        });
+
+        it("should include parseDate", function() {
+          var result = Globalize.parseDate("1/2/1982");
+          expect(result.getFullYear()).to.equal(1982);
+          expect(result.getMonth()).to.equal(0);
+          expect(result.getDate()).to.equal(2);
+        });
+      });
+    });
+  });
+});

--- a/test/fixtures/app.js
+++ b/test/fixtures/app.js
@@ -1,0 +1,33 @@
+var like;
+var Globalize = require( "globalize" );
+
+// Use Globalize to format dates.
+console.log( Globalize.formatDate( new Date(), { datetime: "medium" } ) );
+
+// Use Globalize to format numbers.
+console.log( Globalize.formatNumber( 12345.6789 ) );
+
+// Use Globalize to format currencies.
+console.log( Globalize.formatCurrency( 69900, "USD" ) );
+
+// Use Globalize to get the plural form of a numeric value.
+console.log( Globalize.plural( 12345.6789 ) );
+
+// Use Globalize to format a message with plural inflection.
+like = Globalize.messageFormatter( "like" );
+console.log( like( 0 ) );
+console.log( like( 1 ) );
+console.log( like( 2 ) );
+console.log( like( 3 ) );
+
+// Use Globalize to format relative time.
+console.log( Globalize.formatRelativeTime( -35, "second" ) );
+
+// Use Globalize to format unit.
+console.log( Globalize.formatUnit( 60, "mile/hour", { form: "short" } ) );
+
+// Use Globalize to parse a number.
+console.log( Globalize.parseNumber( "12345.6789" ) );
+
+// Use Globalize to parse a date.
+console.log( Globalize.parseDate( "1/2/1982" ) );

--- a/test/fixtures/translations/en.json
+++ b/test/fixtures/translations/en.json
@@ -1,0 +1,12 @@
+{
+	"en": {
+		"like": [
+			"{0, plural, offset:1",
+			"     =0 {Be the first to like this}",
+			"     =1 {You liked this}",
+			"    one {You and someone else liked this}",
+			"  other {You and # others liked this}",
+			"}"
+		]
+	}
+}

--- a/test/index.js
+++ b/test/index.js
@@ -1,0 +1,3 @@
+var chai = require("chai");
+var chaiAsPromised = require("chai-as-promised");
+chai.use(chaiAsPromised);

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,0 +1,1 @@
+--require test/index


### PR DESCRIPTION
It was time to have tests in place. This PR finally adds test cases, including ones actually using the generated production bundle.

Ideas for improvement are welcome:
- We need to test webpack 1 and webpack 2.. Can we npm install both simultaneously? A little research showed it's a little hassle. Should we stop supporting both simultaneously and instead support each in different globalize-webpack-plugin versions instead?
- How can I cleanly import a module from within the generated bundle. Currently, I'm using a little hack to do so.