### PR TITLE
fix hashing of RawModules

### DIFF
--- a/PatchedRawModule.js
+++ b/PatchedRawModule.js
@@ -1,0 +1,15 @@
+"use strict";
+
+const RawModule = require("webpack/lib/RawModule");
+
+class PatchedRawModule extends RawModule {
+  // RawModule has a regression in webpack-2 where it does not include its own
+  // source in the module hash.
+  // See https://github.com/webpack/webpack/issues/5070
+  updateHash(hash) {
+    hash.update(this.sourceStr);
+    super.updateHash(hash);
+  }
+}
+
+module.exports = PatchedRawModule;

--- a/ProductionModePlugin.js
+++ b/ProductionModePlugin.js
@@ -4,7 +4,7 @@ const CommonJsRequireDependency = require("webpack/lib/dependencies/CommonJsRequ
 const GlobalizeCompilerHelper = require("./GlobalizeCompilerHelper");
 const MultiEntryPlugin = require("webpack/lib/MultiEntryPlugin");
 const NormalModuleReplacementPlugin = require("webpack/lib/NormalModuleReplacementPlugin");
-const RawModule = require("webpack/lib/RawModule");
+const PatchedRawModule = require("./PatchedRawModule");
 const SkipAMDPlugin = require("skip-amd-webpack-plugin");
 const util = require("./util");
 
@@ -255,7 +255,7 @@ class ProductionModePlugin {
               // any modifications we make will be rendered into every locale
               // chunk. Create a new module to contain the locale-specific source
               // modifications we've made.
-              const newModule = new RawModule(fnContent);
+              const newModule = new PatchedRawModule(fnContent);
               newModule.context = module.context;
               newModule.id = module.id;
               newModule.dependencies = module.dependencies;

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   "peerDependencies": {
     "cldr-data": ">=25",
     "globalize": "^1.1.0-rc.5 <1.3.0",
-    "webpack": "^2.5.1"
+    "webpack": "^2.2.0-rc"
   },
   "devDependencies": {
     "chai": "^3.5.0",

--- a/test/PatchedRawModule.js
+++ b/test/PatchedRawModule.js
@@ -1,0 +1,27 @@
+"use strict";
+
+const crypto = require("crypto");
+const expect = require("chai").expect;
+const PatchedRawModule = require("../PatchedRawModule");
+
+const hashModule = (module) => {
+  const hash = crypto.createHash("sha256");
+  module.updateHash(hash);
+  return hash.digest("hex");
+};
+
+describe("PatchedRawModule", () => {
+  describe("updateHash", () => {
+    it("should produce the same hash for modules with the same source", () => {
+      const a = new PatchedRawModule("foo");
+      const b = new PatchedRawModule("foo");
+      expect(hashModule(a)).to.equal(hashModule(b));
+    });
+
+    it("should produce different hashes for modules with different source", () => {
+      const a = new PatchedRawModule("foo");
+      const b = new PatchedRawModule("bar");
+      expect(hashModule(a)).to.not.equal(hashModule(b));
+    });
+  });
+});


### PR DESCRIPTION
webpack-2 appears to have a [bug](https://github.com/webpack/webpack/issues/5070) where RawModules can produce hash collisions. Since globalize-webpack-plugin-1.0.0 introduced use of RawModules, this package is susceptible to emitting chunks with different contents but unchanged chunkhashes. This can cause cdns and browser caches to unwittingly use old assets and lead to irksome bugs.

Even though the root issue appears to be in webpack, this package should be patched to work around the issue in the versions of webpack that it supports.

Additionally, the required webpack version here is downgraded to match what is required by react-globalize-webpack-plugin.