### PR TITLE
Don’t mess with webpack calculated dependencies

### DIFF
--- a/GlobalizeCompilerHelper.js
+++ b/GlobalizeCompilerHelper.js
@@ -74,7 +74,7 @@ class GlobalizeCompilerHelper {
       if (!/No formatters or parsers has been provided/.test(e.message) || !request) {
         throw e;
       }
-      content = "module.exports = {};";
+      content = "module.exports = require(\"globalize\");";
     }
 
     // Inject set defaultLocale.


### PR DESCRIPTION
This fixes [this](https://github.com/webpack/webpack/issues/4990) blocking (for us anyway !) webpack issue which wasn't webpack's fault.

When ProductionModePlugin [rewrites](https://github.com/rxaviers/globalize-webpack-plugin/blob/master/ProductionModePlugin.js#L226) the modules,
1. It sets all but the new entry module (picked “randomly”, see below) to [`module.exports = __webpack_require__(${globalizeModuleIds[0]});`](https://github.com/rxaviers/globalize-webpack-plugin/blob/master/ProductionModePlugin.js#L226)* whereas some module might just be `module.exports = {};` leading Wepback to consider that `__webpack_require__` isn’t necessary, resulting in a module glue like `function(module, exports) {` (missing third parameter) which leads to a runtime crash.
2. Like said above, the entry module being “randomly chosen”, it can be an empty module (`module.exports = {};`) overwritten with Globalize code leading to the same `__webpack_require__` crash as in 1.

*As a side note, `globalizeModuleIds[0]` implies that `'globalize'` is the first globalize entry in webpack.config chunk configuration. We should probably document that explicitely.

Signed-off-by: Frédéric Miserey <frederic@none.net>