### PR TITLE
module.chunks getter is deprecated in webpack-3

### DIFF
--- a/ProductionModePlugin.js
+++ b/ProductionModePlugin.js
@@ -128,7 +128,7 @@ class ProductionModePlugin {
         const compiledDataChunks = chunks.filter((chunk) => /globalize-compiled-data/.test(chunk.name));
 
         allModules.forEach((module) => {
-          let chunkRemoved, chunk;
+          let chunkRemoved;
           if (globalizeCompilerHelper.isCompiledDataModule(module.request)) {
             hasAnyModuleBeenIncluded = true;
             module.getChunks().forEach((chunk) => {

--- a/ProductionModePlugin.js
+++ b/ProductionModePlugin.js
@@ -131,13 +131,12 @@ class ProductionModePlugin {
           let chunkRemoved, chunk;
           if (globalizeCompilerHelper.isCompiledDataModule(module.request)) {
             hasAnyModuleBeenIncluded = true;
-            while (module.chunks.length) {
-              chunk = module.chunks[0];
+            module.getChunks().forEach((chunk) => {
               chunkRemoved = module.removeChunk(chunk);
               if (!chunkRemoved) {
                 throw new Error("Failed to remove chunk " + chunk.id + " for module " + module.request);
               }
-            }
+            });
             compiledDataChunks.forEach((compiledDataChunk) => {
               compiledDataChunk.addModule(module);
               module.addChunk(compiledDataChunk);

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   "peerDependencies": {
     "cldr-data": ">=25",
     "globalize": "^1.1.0-rc.5 <1.3.0",
-    "webpack": "^2.5.1"
+    "webpack": "^3.0.0"
   },
   "devDependencies": {
     "chai": "^3.5.0",
@@ -53,9 +53,8 @@
     "globalize": "^1.2.3 <1.3.0",
     "mkdirp": "^0.5.1",
     "mocha": "^3.3.0",
-    "path-chunk-webpack-plugin": "^1.2.0",
     "rimraf": "^2.6.1",
-    "webpack": "^2.5.1"
+    "webpack": "^3.0.0"
   },
   "cldr-data-urls-filter": "(core|dates|numbers|units)"
 }

--- a/test/ProductionModePlugin.js
+++ b/test/ProductionModePlugin.js
@@ -96,7 +96,7 @@ function commonTests(testName, webpackConfig, outputPath) {
       require(mkOutputPath(testName, "app"));
 
       const globalizeModuleStats = compileStats.toJson().modules.find((module) => {
-        return module.name === "./~/globalize/dist/globalize-runtime.js";
+        return module.name === "./node_modules/globalize/dist/globalize-runtime.js";
       });
 
       Globalize = global.__webpack_require__(globalizeModuleStats.id);


### PR DESCRIPTION
use getChunks instead (mutable safe)

Signed-off-by: Frédéric Miserey <frederic@none.net>