### PR TITLE
Add option to disable cldr

### DIFF
--- a/DevelopmentModePlugin.js
+++ b/DevelopmentModePlugin.js
@@ -13,28 +13,31 @@ const util = require("./util");
  */
 class DevelopmentModePlugin {
   constructor(attributes) {
+    this.disableCldr = attributes.disableCldr;
     let i18nDataTemplate, messages;
     const cldr = attributes.cldr || util.cldr;
     const timeZoneData = attributes.timeZoneData || util.timeZoneData;
     const tmpdirBase = attributes.tmpdirBase || ".";
     const tmpdir = util.tmpdir(tmpdirBase);
 
-    messages = attributes.messages && util.readMessages(attributes.messages, attributes.developmentLocale);
+    if (!this.disableCldr) {
+      messages = attributes.messages && util.readMessages(attributes.messages, attributes.developmentLocale);
 
-    i18nDataTemplate = [
-      "var Globalize = require(\"globalize\");",
-      "",
-      `Globalize.load(${JSON.stringify(cldr(attributes.developmentLocale))});`,
-      messages ? `Globalize.loadMessages(${JSON.stringify(messages)});` : "",
-      `Globalize.loadTimeZone(${JSON.stringify(timeZoneData())});`,
-      `Globalize.locale(${JSON.stringify(attributes.developmentLocale)});`,
-      "",
-      "module.exports = Globalize;"
-    ].join("\n");
+      i18nDataTemplate = [
+        "var Globalize = require(\"globalize\");",
+        "",
+        `Globalize.load(${JSON.stringify(cldr(attributes.developmentLocale))});`,
+        messages ? `Globalize.loadMessages(${JSON.stringify(messages)});` : "",
+        `Globalize.loadTimeZone(${JSON.stringify(timeZoneData())});`,
+        `Globalize.locale(${JSON.stringify(attributes.developmentLocale)});`,
+        "",
+        "module.exports = Globalize;"
+      ].join("\n");
 
-    this.i18nData = path.join(tmpdir, "dev-i18n-data.js");
-    this.moduleFilter = util.moduleFilterFn(attributes.moduleFilter);
-    fs.writeFileSync(this.i18nData, i18nDataTemplate);
+      this.i18nData = path.join(tmpdir, "dev-i18n-data.js");
+      this.moduleFilter = util.moduleFilterFn(attributes.moduleFilter);
+      fs.writeFileSync(this.i18nData, i18nDataTemplate);
+    }
   }
 
   apply(compiler) {
@@ -45,24 +48,26 @@ class DevelopmentModePlugin {
     // `require` to our custom generated template, which in turn requires
     // Globalize, loads CLDR, set the default locale and then exports the
     // Globalize object.
-    compiler.plugin("compilation", (compilation, params) => {
-      params.normalModuleFactory.plugin("parser", (parser) => {
-        parser.plugin("call require:commonjs:item", (expr, param) => {
-          const request = parser.state.current.request;
+    if (!this.disableCldr) {
+      compiler.plugin("compilation", (compilation, params) => {
+        params.normalModuleFactory.plugin("parser", (parser) => {
+          parser.plugin("call require:commonjs:item", (expr, param) => {
+            const request = parser.state.current.request;
 
-          if(param.isString() && param.string === "globalize" && this.moduleFilter(request) &&
-            !(new RegExp(util.escapeRegex(this.i18nData))).test(request)) {
+            if(param.isString() && param.string === "globalize" && this.moduleFilter(request) &&
+              !(new RegExp(util.escapeRegex(this.i18nData))).test(request)) {
 
-            const dep = new CommonJsRequireDependency(this.i18nData, param.range);
-            dep.loc = expr.loc;
-            dep.optional = !!parser.scope.inTry;
-            parser.state.current.addDependency(dep);
+              const dep = new CommonJsRequireDependency(this.i18nData, param.range);
+              dep.loc = expr.loc;
+              dep.optional = !!parser.scope.inTry;
+              parser.state.current.addDependency(dep);
 
-            return true;
-          }
+              return true;
+            }
+          });
         });
       });
-    });
+    }
   }
 }
 

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ new globalizePlugin({
 	output: "globalize-compiled-data-[locale].[hash].js", // build output.
 	moduleFilter: filterFunction, // filter for modules to exclude from processing
 	tempdirBase: ".", // optional for non create-react-apps
+	disableCldr: true/false // optional for not automatically loading CLDR in development mode
 })
 ```
 
@@ -71,6 +72,8 @@ new globalizePlugin({
 *moduleFilter* (optional) is a function to test on filepaths, and optionally reject matching files from further processing. See [react-globalize-webpack-plugin](https://github.com/rxaviers/react-globalize-webpack-plugin) for an example usage. Globalize's internal modules are not processed by default.
 
 *tmpdirBase* tells the plugin where to create its temporary files. It should be set it to `paths.appSrc` in ejected [create-react-app](https://github.com/facebookincubator/create-react-app)s to comply with its ModuleScopePlugin.
+
+*disableCldr* (optional) is a boolean that tells the plugin to not automatically load CLDR data in development mode.
 
 ## Example
 


### PR DESCRIPTION
This is for disabling loading CLDR data automatically. My use case for this plugin is to solve the issue described in https://github.com/globalizejs/globalize/issues/441 (skipping AMD) , and since for my application I obtain CLDR data at runtime I don't need it at build time. Do you think this is will be a common use case? Is it possible to use `skip-amd-webpack-plugin` without `globalize-webpack-plugin`? Thank you