### PR TITLE
try to migrate from CommonChunksPlugin to optimization.splitChunks

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,13 +38,13 @@
     "cldr-data": ">=25",
     "globalize-compiler": "^1.0.0",
     "iana-tz-data": ">=2017.0.0",
-    "skip-amd-webpack-plugin": "0.2.x"
+    "skip-amd-webpack-plugin": "^1.0.0"
   },
   "peerDependencies": {
     "cldr-data": ">=25",
     "globalize": "^1.3.0",
     "iana-tz-data": ">=2017.0.0",
-    "webpack": "^3.0.0"
+    "webpack": "^4.0.0"
   },
   "devDependencies": {
     "chai": "^3.5.0",
@@ -57,7 +57,7 @@
     "mkdirp": "^0.5.1",
     "mocha": "^3.3.0",
     "rimraf": "^2.6.1",
-    "webpack": "^3.0.0"
+    "webpack": "^4.0.0"
   },
   "cldr-data-urls-filter": "(core|dates|numbers|units)"
 }

--- a/test/ProductionModePlugin.js
+++ b/test/ProductionModePlugin.js
@@ -20,6 +20,18 @@ const mkWebpackConfig = (options) => ({
     path: options.outputPath,
     filename: "app.js"
   },
+  optimization: {
+    splitChunks: {
+      cacheGroups: {
+        vendor: {
+          test: /[\\/]node_modules[\\/]/,
+          priority: -10
+        },
+        runtime: {
+        }
+      }
+    }
+  },
   plugins: [
     new GlobalizePlugin(
       Object.assign(
@@ -33,20 +45,7 @@ const mkWebpackConfig = (options) => ({
         },
         options.additionalGWPAttributes
       )
-    ),
-    new webpack.optimize.CommonsChunkPlugin({
-      name: "vendor",
-      filename: "vendor.js",
-      minChunks: (module) => {
-        const nodeModules = path.resolve(__dirname, "../node_modules");
-        return module.request && module.request.startsWith(nodeModules);
-      }
-    }),
-    new webpack.optimize.CommonsChunkPlugin({
-      name: "runtime",
-      filename: "runtime.js",
-      minChunks: Infinity
-    })
+    )
   ].concat(options.additionalPlugins || [])
 });
 


### PR DESCRIPTION
Mostly following https://gist.github.com/sokra/1522d586b8e5c0f5072d7565c2bee693

I didn't get far though. Current output:

```
> globalize-webpack-plugin@2.1.0 test /Users/joern.zaefferer/dev/other/globalize-webpack-plugin
> mocha test

  PatchedRawModule
    updateHash
      ✓ should produce the same hash for modules with the same source
      ✓ should produce different hashes for modules with different source

  Globalize Webpack Plugin
    Production Mode
      Custom tempdir
(node:17457) DeprecationWarning: Tapable.apply is deprecated. Call apply on the plugin directly instead
(node:17457) DeprecationWarning: Tapable.plugin is deprecated. Use new API on `.hooks` instead
No Globalize compiled data module found
(node:17457) DeprecationWarning: Chunk.forEachModule: Use for(const module of chunk.modulesIterable) instead
(node:17457) DeprecationWarning: Chunk.mapModules: Use Array.from(chunk.modulesIterable, fn) instead
        ✓ should extract formatters and parsers from basic code
        The compiled bundle
          1) "before all" hook for "should extract formatters and parsers from basic code"
      Default module ids
No Globalize compiled data module found
[...]


  6 passing (518ms)
  4 failing

  1) Globalize Webpack Plugin Production Mode Custom tempdir The compiled bundle "before all" hook for "should extract formatters and parsers from basic code":
     Error: ENOENT: no such file or directory, open '/Users/joern.zaefferer/dev/other/globalize-webpack-plugin/_test-output/tempdir/runtime.js'
      at Object.fs.openSync (fs.js:646:18)
      at Object.fs.readFileSync (fs.js:551:33)
      at Context.before (test/ProductionModePlugin.js:104:33)

[...]
```