### PR TITLE
Amend "Allow multiple compiled-data chunks at once"

### DIFF
--- a/test/ProductionModePlugin.js
+++ b/test/ProductionModePlugin.js
@@ -60,6 +60,8 @@ const promisefiedWebpack = (config) => new Promise((resolve, reject) => {
 });
 
 function commonTests(testName, webpackConfig, outputPath) {
+  let Globalize;
+  let GlobalizeWebpackId;
   let compileStats;
 
   before((done) => {
@@ -68,10 +70,35 @@ function commonTests(testName, webpackConfig, outputPath) {
       promisefiedWebpack(webpackConfig)
         .then((stats) => {
           compileStats = stats;
+
+          global.window = global;
+          // Hack: Expose __webpack_require__.
+          const runtimeFilePath = mkOutputPath(testName, "runtime.js");
+          const runtimeContent = fs.readFileSync(runtimeFilePath).toString();
+          fs.writeFileSync(runtimeFilePath, runtimeContent.replace(/(function __webpack_require__\(moduleId\) {)/, "window.__webpack_require__ = $1"));
+
+          // Hack2: Load compiled Globalize
+          require(mkOutputPath(testName, "runtime"));
+          require(mkOutputPath(testName, "vendor"));
+          require(mkOutputPath(testName, "en"));
+          require(mkOutputPath(testName, "app"));
+
+          const globalizeModuleStats = compileStats.toJson().modules.find((module) => {
+            return module.name === "./node_modules/globalize/dist/globalize-runtime.js";
+          });
+
+          GlobalizeWebpackId = globalizeModuleStats.id;
+          Globalize = global.__webpack_require__(GlobalizeWebpackId);
+
           done();
         })
         .catch(done);
     });
+  });
+
+  after(() => {
+    delete global.window;
+    delete global.webpackJsonp;
   });
 
   it("should extract formatters and parsers from basic code", () => {
@@ -82,34 +109,14 @@ function commonTests(testName, webpackConfig, outputPath) {
     expect(content).to.be.a("string");
   });
 
+  it("should transform app's imports from globalize into globalize-runtime", () => {
+    const appFilePath = mkOutputPath(testName, "app.js");
+    const appContent = fs.readFileSync(appFilePath).toString();
+
+    expect(appContent).to.contain(`const Globalize = __webpack_require__( ${JSON.stringify(GlobalizeWebpackId)} );`);
+  });
+
   describe("The compiled bundle", () => {
-    let Globalize;
-
-    before(() => {
-      global.window = global;
-      // Hack: Expose __webpack_require__.
-      const runtimeFilePath = mkOutputPath(testName, "runtime.js");
-      const runtimeContent = fs.readFileSync(runtimeFilePath).toString();
-      fs.writeFileSync(runtimeFilePath, runtimeContent.replace(/(function __webpack_require__\(moduleId\) {)/, "window.__webpack_require__ = $1"));
-
-      // Hack2: Load compiled Globalize
-      require(mkOutputPath(testName, "runtime"));
-      require(mkOutputPath(testName, "vendor"));
-      require(mkOutputPath(testName, "en"));
-      require(mkOutputPath(testName, "app"));
-
-      const globalizeModuleStats = compileStats.toJson().modules.find((module) => {
-        return module.name === "./node_modules/globalize/dist/globalize-runtime.js";
-      });
-
-      Globalize = global.__webpack_require__(globalizeModuleStats.id);
-    });
-
-    after(() => {
-      delete global.window;
-      delete global.webpackJsonp;
-    });
-
     it("should render locale chunk with correct entry module", () => {
       const enFilePath = mkOutputPath(testName, "en.js");
       const enContent = fs.readFileSync(enFilePath).toString();


### PR DESCRIPTION
## Problem

After [allow multiple compiled-data chunks at once](https://github.com/rxaviers/globalize-webpack-plugin/commit/8f39cc6584faa4b4fb75e64b4efbfd8bb41133de), it's hard to use the compiled i18n bundles. Please, see problem details below.

## Solution

A very simple change still preserves the "multiple compiled-data chunks at once" feature and fixes the regression.

## Details

### Problem details

**On production**, globalize imports [1] are transformed into corresponding  precompiled formatters and parsers imports. After [allow multiple compiled-data chunks at once](https://github.com/rxaviers/globalize-webpack-plugin/commit/8f39cc6584faa4b4fb75e64b4efbfd8bb41133de), the transformation becames constrained to the default locale [2].

1: app.js (source)

```js
import Globalize from "globalize";
```

2: app.js (production bundle)

```js
import Globalize from `${precompiledFormattersAndParsersForLocaleX}`;
// Named example:
// Globalize = __webpack_require__( "./.tmp-globalize-webpack/-globalize-webpack-plugin-test-fixtures-app-js-en.js" );
```

Note: The precompiled bundle imports needed globalize runtime modules, includes minimal/optimized i18n data, and exports "globalize/dist/globalize-runtime".

In order to use a different locale (other than the default - usually English) you need to load a different locale in addition to default locale.

### Solution details

The fix consists on simply not transforming globalize runtime imports, i.e., the globalize imports [1] are transformed into globalize runtime imports [2] and stays like that. The precompiled formatters and parsers are still extracted and generated the same way.

1: app.js (source)

```js
import Globalize from "globalize";
```

2: app.js (production bundle)

```js
import Globalize from "globalize/dist/globalize-runtime";
// Named example:
// const Globalize = __webpack_require__( "./node_modules/globalize/dist/globalize-runtime.js" );
```

Nothing changes in the way we use/load the bundles, i.e.:

1. Load `vendors.js`
2. Load `i18n/<locale.js>`
3. Load `app.js`

## 